### PR TITLE
カーソルのサイズ修正

### DIFF
--- a/Battleship/BattleshipGame.vb
+++ b/Battleship/BattleshipGame.vb
@@ -167,7 +167,7 @@
                 ElseIf table(i)(j) = TypeOfSquare.Miss Then
                     Console.Write("×")
                 Else
-                    Console.Write("  ")
+                    Console.Write("　")
                 End If
             Next
             Console.WriteLine("|")


### PR DESCRIPTION
 #### 攻撃済みのマスと未攻撃マスのカーソルのサイズが違っていたため修正しました
 不足しているところ、よりよい方法がありましたら教えていただきたいです。
 お忙しいところ恐れ入りますが、よろしくお願いいたします。