### PR TITLE
残弾数をテーブルの右側に表示するように処理変更

### DIFF
--- a/Battleship/Message/ProjectAMessage.vb
+++ b/Battleship/Message/ProjectAMessage.vb
@@ -11,7 +11,7 @@
         ''' </summary>
         ''' <param name="gameTableValue">テーブルの大きさ</param>
         Public Sub New(gameTableValue As GameTableValue)
-            TopPositionToDisplayMessage = gameTableValue.BottomEdge + 3
+            TopPositionToDisplayMessage = gameTableValue.BottomEdge + 2
         End Sub
 
         ''' <summary>

--- a/Battleship/ScreenRemainingBullets.vb
+++ b/Battleship/ScreenRemainingBullets.vb
@@ -2,15 +2,18 @@
 ''' 画面に表示されている残弾数を管理する処理を持つクラス
 ''' </summary>
 Public Class ScreenRemainingBullets
-    ''' <summary>残弾数を表示する垂直での位置</summary>
-    Private ReadOnly topPositionToDisplayRemainingBullet As Integer
+    ''' <summary>残弾数を表示する垂直での開始位置</summary>
+    Private ReadOnly startTopPosition As Integer
+    ''' <summary>残弾数を表示する水平での開始位置</summary>
+    Private ReadOnly startLeftPosition As Integer
 
     ''' <summary>
-    ''' テーブルの大きさをもとに残弾数を表示する垂直での位置を設定する
+    ''' テーブルの大きさをもとに残弾数を表示する位置を設定する
     ''' </summary>
     ''' <param name="gameTableValue">テーブルの大きさ</param>
     Public Sub New(gameTableValue As GameTableValue)
-        topPositionToDisplayRemainingBullet = gameTableValue.BottomEdge + 2
+        startTopPosition = gameTableValue.TopEdge - 2
+        startLeftPosition = gameTableValue.RightEdge + 5
     End Sub
 
 
@@ -25,13 +28,39 @@ Public Class ScreenRemainingBullets
         Dim usedBullet As Integer = bulletsAtStart - remainingBullet
         CursorVisible.GetInstance.HideCursor()
         Try
-            Console.SetCursorPosition(0, topPositionToDisplayRemainingBullet)
-            Console.Write("残弾：" & New String("◯"c, remainingBullet) & New String("×"c, usedBullet))
+            Console.SetCursorPosition(startLeftPosition, startTopPosition)
+            DisplayOnScreen(displayRemainingBullet:=(New String("◯"c, remainingBullet) & New String("×"c, usedBullet)).ToCharArray)
             Console.SetCursorPosition(cursorLeft, cursorTop)
         Finally
             CursorVisible.GetInstance.ShowCursor()
         End Try
 
+    End Sub
+
+    ''' <summary>
+    ''' 画面に表示する
+    ''' </summary>
+    ''' <param name="displayRemainingBullet">表示する残弾</param>
+    Private Sub DisplayOnScreen(displayRemainingBullet As Char())
+        '弾数を表示する列数
+        Const COUNT_OF_COLUMN As Integer = 3
+        Dim turningPoint As Integer = CInt(displayRemainingBullet.Length / COUNT_OF_COLUMN)
+        Console.Write(" 残弾")
+        Dim count As Integer = 0
+        Dim leftPosition As Integer = startLeftPosition
+        Console.SetCursorPosition(startLeftPosition, startTopPosition + 2)
+        For arrayIndex As Integer = 0 To displayRemainingBullet.Length - 1
+            If turningPoint = count Then
+                count = 0
+                leftPosition += 2
+                Console.SetCursorPosition(leftPosition, startTopPosition + 2)
+                arrayIndex -= 1
+                Continue For
+            End If
+            Console.Write(displayRemainingBullet(arrayIndex))
+            Console.SetCursorPosition(leftPosition, Console.CursorTop + 1)
+            count += 1
+        Next
     End Sub
 
 End Class


### PR DESCRIPTION
 #### 残弾数の表示をテーブルの右側に表示するように処理を変更しました。
 不足しているところ、不適切なところ、よりよい方法がありましたら教えていただきたいです。
 お忙しいところ恐れ入りますが、よろしくお願いいたします。